### PR TITLE
added uint160 cast to support the conversion in v0.8.0

### DIFF
--- a/contracts/libraries/UniswapV2Library.sol
+++ b/contracts/libraries/UniswapV2Library.sol
@@ -17,12 +17,12 @@ library UniswapV2Library {
     // calculates the CREATE2 address for a pair without making any external calls
     function pairFor(address factory, address tokenA, address tokenB) internal pure returns (address pair) {
         (address token0, address token1) = sortTokens(tokenA, tokenB);
-        pair = address(uint(keccak256(abi.encodePacked(
+        pair = address(uint160(uint(keccak256(abi.encodePacked(
                 hex'ff',
                 factory,
                 keccak256(abi.encodePacked(token0, token1)),
                 hex'96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f' // init code hash
-            ))));
+            )))));
     }
 
     // fetches and sorts the reserves for a pair


### PR DESCRIPTION
- the direct casting of uint256 to address is not supported in solidity 0.8.0.
- converted it to uint then uint160 then address solves this issue.